### PR TITLE
Fix missing access token in user requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.yvasyliev</groupId>
     <artifactId>deezer-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <name>Deezer API Java Library</name>
     <description>A Java implementation of Deezer API.</description>
     <url>https://github.com/yvasyliev/deezer-api</url>

--- a/src/main/java/api/deezer/requests/UserRequests.java
+++ b/src/main/java/api/deezer/requests/UserRequests.java
@@ -73,6 +73,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<AlbumData> getFavouriteAlbums(long userId) {
         return new PaginationRequest<>(
                 property("user.albums", userId),
+                accessTokenParam(),
                 AlbumData.class
         );
     }
@@ -86,6 +87,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<ArtistData> getFavouriteArtists(long userId) {
         return new PaginationRequest<>(
                 property("user.artists", userId),
+                accessTokenParam(),
                 ArtistData.class
         );
     }
@@ -112,6 +114,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<UserData> getFollowings(long userId) {
         return new PaginationRequest<>(
                 property("user.followings", userId),
+                accessTokenParam(),
                 UserData.class
         );
     }
@@ -125,6 +128,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<UserData> getFollowers(long userId) {
         return new PaginationRequest<>(
                 property("user.followers", userId),
+                accessTokenParam(),
                 UserData.class
         );
     }
@@ -206,6 +210,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<PlaylistData> getPlaylists(long userId) {
         return new PaginationRequest<>(
                 property("user.playlists", userId),
+                accessTokenParam(),
                 PlaylistData.class
         );
     }
@@ -219,6 +224,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<RadioData> getFavouriteRadios(long userId) {
         return new PaginationRequest<>(
                 property("user.radios", userId),
+                accessTokenParam(),
                 RadioData.class
         );
     }
@@ -310,6 +316,7 @@ public class UserRequests extends DeezerRequests {
     public PaginationRequest<TrackData> getFavouriteTracks(long userId) {
         return new PaginationRequest<>(
                 property("user.tracks", userId),
+                accessTokenParam(),
                 TrackData.class
         );
     }

--- a/src/test/java/api/deezer/requests/UserRequestsTest.java
+++ b/src/test/java/api/deezer/requests/UserRequestsTest.java
@@ -41,6 +41,7 @@ class UserRequestsTest {
         PaginationRequest<AlbumData> request = deezerApi.user().getFavouriteAlbums(123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123/albums", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }
@@ -50,6 +51,7 @@ class UserRequestsTest {
         PaginationRequest<ArtistData> request = deezerApi.user().getFavouriteArtists(123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123/artists", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }
@@ -69,6 +71,7 @@ class UserRequestsTest {
         PaginationRequest<UserData> request = deezerApi.user().getFollowings(123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123/followings", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }
@@ -78,6 +81,7 @@ class UserRequestsTest {
         PaginationRequest<UserData> request = deezerApi.user().getFollowers(123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123/followers", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }
@@ -131,6 +135,7 @@ class UserRequestsTest {
         PaginationRequest<PlaylistData> request = deezerApi.user().getPlaylists(123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123/playlists", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }
@@ -140,6 +145,7 @@ class UserRequestsTest {
         PaginationRequest<RadioData> request = deezerApi.user().getFavouriteRadios(123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123/radios", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }
@@ -209,6 +215,7 @@ class UserRequestsTest {
         PaginationRequest<TrackData> request = deezerApi.user().getFavouriteTracks(123123123123123L).limit(5).offset(1);
         assertEquals("https://api.deezer.com/user/123123123123123/tracks", request.getUrl());
         assertEquals("get", request.getParams().get("request_method"));
+        assertEquals("accessToken", request.getParams().get("access_token"));
         assertEquals("5", request.getParams().get("limit"));
         assertEquals("1", request.getParams().get("offset"));
     }


### PR DESCRIPTION
Hi,

Several uses of the access token seem to be missing in the `UserRequests` class. An access token is indeed needed to fetch a user's...

- ...favorite albums
- ...favorite artists
- ...followings
- ...followers
- ...playlists
- ...favorite radios
- ...favorite tracks

I am submitting a small PR to fix this behavior.