### PR TITLE
ci(pr-build): build PR branch in a dedicated environment

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   pr-build:
     runs-on: ubuntu-latest
+    environment: pr-review
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7


### PR DESCRIPTION
## Description

Allows building PR branches in a safe environment.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [ ] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [ ] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
