### PR TITLE
feat: add track lookup by ISRC

### DIFF
--- a/bruno-collection/opencollection.yml
+++ b/bruno-collection/opencollection.yml
@@ -33,6 +33,8 @@ request:
       value: "605632582"
     - name: track-id
       value: "541999"
+    - name: track-isrc
+      value: "USRC18207933"
 bundled: false
 extensions:
   ignore:

--- a/bruno-collection/track/get-track-by-isrc.yml
+++ b/bruno-collection/track/get-track-by-isrc.yml
@@ -1,0 +1,15 @@
+info:
+  name: get-track-by-isrc
+  type: http
+  seq: 3
+
+http:
+  method: GET
+  url: "{{api-host}}/track/isrc:{{track-isrc}}"
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/src/integrationTest/java/io/github/yvasyliev/dz4j/TrackIT.java
+++ b/src/integrationTest/java/io/github/yvasyliev/dz4j/TrackIT.java
@@ -46,6 +46,20 @@ class TrackIT extends AbstractIT {
     }
 
     @Test
+    void shouldReturnTrackByIsrc() throws IOException {
+        var isrc = "USRC18207933";
+        var body = read("/response/track/get-track-maneater.json");
+        var expected = MAPPER.readValue(body, Track.class);
+
+        stubFor(get(urlPathTemplate("/track/isrc:{isrc}"))
+                .withPathParam("isrc", equalTo(isrc))
+                .willReturn(okJson(body))
+        );
+
+        assertEquals(expected, deezerClient.track().getTrackByIsrc(isrc));
+    }
+
+    @Test
     void shouldUpdateTrack() throws IOException {
         var trackId = 541999L;
         var title = "My Track";

--- a/src/main/java/io/github/yvasyliev/dz4j/factory/TrackRequestFactory.java
+++ b/src/main/java/io/github/yvasyliev/dz4j/factory/TrackRequestFactory.java
@@ -4,6 +4,7 @@ import io.github.yvasyliev.dz4j.authorization.AuthorizationManager;
 import io.github.yvasyliev.dz4j.model.Track;
 import io.github.yvasyliev.dz4j.request.DeezerRequest;
 import io.github.yvasyliev.dz4j.request.IdDeezerRequest;
+import io.github.yvasyliev.dz4j.request.SimpleDeezerRequest;
 import io.github.yvasyliev.dz4j.request.UpdateTrackDeezerRequest;
 import io.github.yvasyliev.dz4j.service.TrackService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,16 @@ public class TrackRequestFactory {
      */
     public DeezerRequest<Track> getTrack(long trackId) {
         return new IdDeezerRequest<>(trackId, trackService::getTrack);
+    }
+
+    /**
+     * Creates a request to get a track by its ISRC (International Standard Recording Code).
+     *
+     * @param isrc track ISRC
+     * @return request to get a track
+     */
+    public DeezerRequest<Track> getTrackByIsrc(String isrc) {
+        return new SimpleDeezerRequest<>(() -> trackService.getTrackByIsrc(isrc));
     }
 
     /**

--- a/src/main/java/io/github/yvasyliev/dz4j/service/TrackService.java
+++ b/src/main/java/io/github/yvasyliev/dz4j/service/TrackService.java
@@ -25,6 +25,15 @@ public interface TrackService {
     CompletableFuture<Track> getTrack(@Param("trackId") long trackId);
 
     /**
+     * Returns a track by its ISRC (International Standard Recording Code).
+     *
+     * @param isrc the track's ISRC
+     * @return a track
+     */
+    @RequestLine("GET /track/isrc:{isrc}")
+    CompletableFuture<Track> getTrackByIsrc(@Param("isrc") String isrc);
+
+    /**
      * Updates a user's track information.
      *
      * @param trackId     the track ID

--- a/src/test/java/io/github/yvasyliev/dz4j/factory/TrackRequestFactoryTest.java
+++ b/src/test/java/io/github/yvasyliev/dz4j/factory/TrackRequestFactoryTest.java
@@ -35,6 +35,18 @@ class TrackRequestFactoryTest {
     }
 
     @Test
+    void testGetTrackByIsrc() {
+        var isrc = "USRC18207933";
+        var expected = Track.builder().isrc(isrc).build();
+
+        when(trackService.getTrackByIsrc(isrc)).thenReturn(CompletableFuture.completedFuture(expected));
+
+        var actual = trackRequestFactory.getTrackByIsrc(isrc).execute();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void testUpdateTrack() {
         var trackId = 123L;
         var accessToken = new AccessToken("test-token");


### PR DESCRIPTION
Deezer's API supports GET /track/isrc:{isrc} as an alternative to GET /track/{trackId}, letting callers look up a track directly by its ISRC (International Standard Recording Code) instead of Deezer's own numeric ID. This is the standard way cross-platform music tools match the same recording across services that use different internal IDs.

Adds TrackService.getTrackByIsrc and TrackRequestFactory.getTrackByIsrc, reusing the existing unauthenticated SimpleDeezerRequest wrapper (this endpoint needs no access token, same as getTrack). Includes unit test, WireMock-backed integration test, and a bruno-collection request for manual testing, following the project's existing conventions.

## Description

Please provide a clear and concise description of your changes.

## Related Issue

Closes #[issue-number] (if applicable)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [x] I have added or updated Javadoc for public classes and methods
- [x] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

Please describe the tests you ran to verify your changes.

## Additional Information

Add any other context or screenshots about the pull request here.
