### PR TITLE
chore: add `.cache_ggshield` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+# Added by ggshield
+.cache_ggshield


### PR DESCRIPTION
## Description

Adds `.cache_ggshield` to `.gitignore`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): `.gitignore` update

## Checklist

- [ ] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [ ] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
