### PR TITLE
docs: add `@implNote` to `DeezerRequest`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,12 @@ tasks.withType(JavaCompile).configureEach {
     }
 }
 
+javadoc {
+    options {
+        tags 'implNote:a:Implementation Note:'
+    }
+}
+
 jacocoTestReport {
     dependsOn test, integrationTest
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -7,6 +7,10 @@
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>
 
+    <module name="SuppressionSingleFilter">
+        <property name="message" value="Unknown tag '(implNote|implSpec|apiNote)'"/>
+    </module>
+
     <module name="FileLength"/>
     <module name="FileTabCharacter"/>
     <module name="JavadocPackage"/>
@@ -40,6 +44,9 @@
                             @throws,
                             @author,
                             @version,
+                            @implNote,
+                            @implSpec,
+                            @apiNote,
                             @since"/>
         </module>
         <module name="AvoidNestedBlocks">

--- a/src/main/java/io/github/yvasyliev/dz4j/request/DeezerRequest.java
+++ b/src/main/java/io/github/yvasyliev/dz4j/request/DeezerRequest.java
@@ -7,11 +7,10 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Represents a request to the Deezer API that can be executed synchronously or asynchronously.
  *
- * <p>
- * It's recommended to extend {@link AbstractDeezerRequest} instead of implementing this interface directly for the
- * streamlined handling of exceptions and asynchronous execution.
- *
  * @param <T> the type of the response expected from the Deezer API
+ * @implNote Implementers are encouraged to extend {@link AbstractDeezerRequest} rather than {@code implement}
+ *         this interface directly; the abstract base class provides default exception handling and a standard
+ *         asynchronous implementation.
  */
 public interface DeezerRequest<T> {
     /**


### PR DESCRIPTION
## Description

Adds `@implNote` to `DeezerRequest`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [ ] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [ ] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
