### PR TITLE
test: extract mocks creation to local variables

### DIFF
--- a/src/test/java/io/github/yvasyliev/dz4j/feign/codec/DeezerDecoderTest.java
+++ b/src/test/java/io/github/yvasyliev/dz4j/feign/codec/DeezerDecoderTest.java
@@ -103,10 +103,11 @@ class DeezerDecoderTest {
         @Cleanup var response = Response.builder().request(mock()).body(body).build();
         var type = mock(Type.class);
         var e = mock(JacksonException.class);
+        var cause = mock(IOException.class);
 
         when(body.asInputStream()).thenReturn(inputStream);
         when(jsonMapper.readTree(inputStream)).thenThrow(e);
-        when(e.getCause()).thenReturn(mock(IOException.class));
+        when(e.getCause()).thenReturn(cause);
 
         assertThrows(IOException.class, () -> decoder.decode(response, type));
     }
@@ -131,9 +132,10 @@ class DeezerDecoderTest {
         @Cleanup var inputStream = mock(InputStream.class);
         @Cleanup var response = Response.builder().request(mock()).body(body).build();
         var type = mock(Type.class);
+        var jsonNode = mock(JsonNode.class);
 
         when(body.asInputStream()).thenReturn(inputStream);
-        when(jsonMapper.readTree(inputStream)).thenReturn(mock(JsonNode.class));
+        when(jsonMapper.readTree(inputStream)).thenReturn(jsonNode);
 
         assertThrows(DeezerException.class, () -> decoder.decode(response, type));
     }

--- a/src/test/java/io/github/yvasyliev/dz4j/feign/codec/ErrorDeserializerTest.java
+++ b/src/test/java/io/github/yvasyliev/dz4j/feign/codec/ErrorDeserializerTest.java
@@ -41,11 +41,11 @@ class ErrorDeserializerTest {
     @Test
     void shouldThrowDeezerApiException() {
         var node = JsonNodeFactory.instance.objectNode();
+        var e = mock(DeezerApiResponseException.class);
 
         node.putObject("error");
 
-        when(delegate.deserialize(node.path("error"), AbstractDeezerApiException.class))
-                .thenReturn(mock(DeezerApiResponseException.class));
+        when(delegate.deserialize(node.path("error"), AbstractDeezerApiException.class)).thenReturn(e);
 
         assertThrows(AbstractDeezerApiException.class, () -> deserializer.deserialize(node, Object.class));
     }


### PR DESCRIPTION
## Description

Extracts mocks creation to local variables.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [x] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A