### PR TITLE
chore: migrate dependencies to version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java-library'
     id 'checkstyle'
     id 'jacoco'
+
     alias libs.plugins.lombok
     alias libs.plugins.errorprone
     alias libs.plugins.maven.publish

--- a/build.gradle
+++ b/build.gradle
@@ -174,16 +174,8 @@ mavenPublishing {
             connection = 'scm:git:ssh://github.com/yvasyliev/dz4j.git'
             developerConnection = 'scm:git:ssh://github.com/yvasyliev/dz4j.git'
         }
-
-//        withXml {
-//            asNode().get('dependencyManagement').each { it.parent().remove it }
-//        }
     }
 }
-
-//tasks.withType(GenerateModuleMetadata).configureEach {
-//    enabled = false
-//}
 
 tasks.withType(AbstractArchiveTask).configureEach {
     into('META-INF') {

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ plugins {
     id 'java-library'
     id 'checkstyle'
     id 'jacoco'
-    id 'io.freefair.lombok' version '9.5.0'
-    id 'net.ltgt.errorprone' version '5.1.0'
-    id 'com.vanniktech.maven.publish' version '0.37.0'
-    id 'com.gradleup.shadow' version '9.6.1'
-    id 'org.sonarqube' version '7.4.0.8496'
+    alias libs.plugins.lombok
+    alias libs.plugins.errorprone
+    alias libs.plugins.maven.publish
+    alias libs.plugins.shadow
+    alias libs.plugins.sonarqube
 }
 
 group = 'io.github.yvasyliev'
@@ -25,18 +25,15 @@ repositories {
 }
 
 dependencies {
-    implementation platform('io.github.openfeign:feign-bom:13.13')
-    implementation platform('tools.jackson:jackson-bom:3.2.1')
+    api libs.feign.form
+    api libs.jackson.databind
+    api libs.jspecify
 
-    api 'io.github.openfeign:feign-form'
-    api 'tools.jackson.core:jackson-databind'
-    api 'org.jspecify:jspecify:1.0.1'
+    checkstyle libs.checkstyle
+    checkstyle libs.sevntu.checks
 
-    checkstyle 'com.puppycrawl.tools:checkstyle:13.10.0'
-    checkstyle 'com.github.sevntu-checkstyle:sevntu-checks:1.44.1'
-
-    errorprone 'com.google.errorprone:error_prone_core:2.50.0'
-    errorprone 'com.uber.nullaway:nullaway:0.13.8'
+    errorprone libs.errorprone.core
+    errorprone libs.nullaway
 }
 
 checkstyle {
@@ -59,18 +56,13 @@ testing {
             }
 
             dependencies {
-                implementation platform('org.junit:junit-bom:6.1.3')
-                implementation platform('org.mockito:mockito-bom:5.23.0')
-                implementation platform('org.assertj:assertj-bom:3.27.7')
+                implementation libs.junit.jupiter
+                implementation libs.mockito.junit.jupiter
+                implementation libs.assertj.core
 
-                implementation 'org.junit.jupiter:junit-jupiter'
-                implementation 'org.mockito:mockito-junit-jupiter'
-                implementation 'org.assertj:assertj-core'
+                runtimeOnly libs.junit.platform.launcher
 
-                runtimeOnly 'org.junit.platform:junit-platform-launcher'
-
-                project.dependencies.add 'mockitoAgent', platform('org.mockito:mockito-bom:5.23.0')
-                project.dependencies.add('mockitoAgent', 'org.mockito:mockito-core') {
+                project.dependencies.add('mockitoAgent', libs.mockito.core) {
                     transitive = false
                 }
             }
@@ -83,8 +75,7 @@ testing {
 
             dependencies {
                 implementation project()
-
-                implementation 'org.wiremock:wiremock:3.13.2'
+                implementation libs.wiremock
             }
 
             targets {
@@ -141,18 +132,6 @@ integrationTest {
     finalizedBy jacocoTestReport
 }
 
-publishing {
-    publications {
-        withType(MavenPublication).configureEach {
-            versionMapping {
-                allVariants {
-                    fromResolutionResult()
-                }
-            }
-        }
-    }
-}
-
 shadow {
     addShadowVariantIntoJavaComponent = false
 }
@@ -196,15 +175,15 @@ mavenPublishing {
             developerConnection = 'scm:git:ssh://github.com/yvasyliev/dz4j.git'
         }
 
-        withXml {
-            asNode().get('dependencyManagement').each { it.parent().remove it }
-        }
+//        withXml {
+//            asNode().get('dependencyManagement').each { it.parent().remove it }
+//        }
     }
 }
 
-tasks.withType(GenerateModuleMetadata).configureEach {
-    enabled = false
-}
+//tasks.withType(GenerateModuleMetadata).configureEach {
+//    enabled = false
+//}
 
 tasks.withType(AbstractArchiveTask).configureEach {
     into('META-INF') {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,39 @@
+[versions]
+assertj = "3.27.7"
+checkstyle = "13.10.0"
+errorprone = "2.50.0"
+errorpronePlugin = "5.1.0"
+feign = "13.13"
+jackson = "3.2.1"
+jspecify = "1.0.1"
+junit = "6.1.3"
+lombok = "9.5.0"
+mavenPublish = "0.37.0"
+mockito = "5.23.0"
+nullaway = "0.13.8"
+sevntuCheckstyle = "1.44.1"
+shadow = "9.6.1"
+sonarqube = "7.4.0.8496"
+wiremock = "3.13.2"
+
+[plugins]
+lombok = { id = "io.freefair.lombok", version.ref = "lombok" }
+errorprone = { id = "net.ltgt.errorprone", version.ref = "errorpronePlugin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+
+[libraries]
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
+errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
+feign-form = { module = "io.github.openfeign:feign-form", version.ref = "feign" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind", version.ref = "jackson" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
+sevntu-checks = { module = "com.github.sevntu-checkstyle:sevntu-checks", version.ref = "sevntuCheckstyle" }
+wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }


### PR DESCRIPTION
## Description

Migrate dependencies to version catalog.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe):

## Checklist

- [ ] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [x] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
