### PR TITLE
docs: update link to exception package in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ public class ExceptionHandling {
 ```
 
 Check the
-[io.github.yvasyliev.dz4j.exception](https://javadoc.io/doc/io.github.yvasyliev/dz4j/io/github/yvasyliev/dz4j/exception/package-summary.html)
+[io.github.yvasyliev.dz4j.exception](https://javadoc.io/doc/io.github.yvasyliev/dz4j/latest/io/github/yvasyliev/dz4j/exception/package-summary.html)
 package for all available exceptions.
 
 ## Available API Methods


### PR DESCRIPTION
## Description

Updates link to exception package in `README.md`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [ ] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [ ] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
