### PR TITLE
ci: add condition to skip welcome job for bot users in first-interaction workflow

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   welcome:
+    if: github.event.pull_request.user.type != 'Bot' && github.event.issue.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/first-interaction@v3


### PR DESCRIPTION
## Description

Adds condition to skip welcome job for bot users in first-interaction workflow.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe): first-interaction workflow

## Checklist

- [ ] My code follows the project’s code style and conventions
- [ ] I have added or updated Javadoc for public classes and methods
- [ ] I have added or updated unit tests as needed
- [ ] All tests pass locally (`./gradlew build` or `gradlew.bat build` on Windows)
- [x] I have not committed any secrets (passwords, API keys, etc.)

## How Has This Been Tested?

N/A

## Additional Information

N/A
